### PR TITLE
Add docker_additional_options for specifying other options in daemon.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Role Variables
 Optional variables:
 - `docker_groupmembers`: A list of users who will be added to the `docker` system group, allows docker to be run without sudo
 - `docker_use_ipv4_nic_mtu`: Force Docker to use the MTU set by the main IPV4 interface. This may be necessary on virtualised hosts, see comment in `defaults/main.yml`.
+- `docker_additional_options`: Dictionary of additional Docker configuration options.
 - `docker_use_custom_storage`: If `True` use a custom storage configuration, default `False`
 - `docker_use_custom_network`: If `True` use a custom network configuration, default `False`
 - `docker_systemd_setup`: Set this to False to disable automatic systemd configuration, default `False`.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,19 @@ Simple example (uses default storage overlay driver):
       roles:
         - role: openmicroscopy.docker
 
-Advanced example using custom storage (the LVM volume group `VolGroup00` must already exist):
+Example using the default storage driver, with a dedicated logical volume for docker:
+
+    - hosts: localhost
+      roles:
+        - role: openmicroscopy.lvm-partition
+          lvm_lvname: var_lib_docker
+          lvm_lvmount: /var/lib/docker
+          lvm_lvsize: 100g
+          lvm_lvfilesystem: ext4
+        - role: docker
+
+Advanced example using custom storage and listening on external port 4243 (insecure).
+The LVM volume group `VolGroup00` must already exist:
 
     - hosts: localhost
       roles:
@@ -81,17 +93,10 @@ Advanced example using custom storage (the LVM volume group `VolGroup00` must al
           docker_metadatasize: 100m
           docker_volumesize: 5g
           docker_groupmembers: [centos]
-
-Example using the default storage driver, with a dedicate logical volume for docker:
-
-    - hosts: localhost
-      roles:
-        - role: openmicroscopy.lvm-partition
-          lvm_lvname: var_lib_docker
-          lvm_lvmount: /var/lib/docker
-          lvm_lvsize: 100g
-          lvm_lvfilesystem: ext4
-        - role: docker
+          docker_additional_options:
+            hosts:
+              - tcp://0.0.0.0:4243
+              - unix:///var/run/docker.sock
 
 
 Author Information

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,9 @@ docker_lvfilesystem: xfs
 # TODO: Add an option to explicitly set the MTU in case auto-detection fails
 docker_use_ipv4_nic_mtu: False
 
+# Dictionary of additional docker options
+docker_additional_options: {}
+
 # Users who can run docker
 docker_groupmembers: []
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,3 +2,14 @@
 - hosts: all
   roles:
     - role: ansible-role-docker
+      docker_additional_options:
+        hosts:
+          - tcp://127.0.0.1:4243
+          - unix:///var/run/docker.sock
+
+  tasks:
+    - name: create unprivileged user
+      become: yes
+      user:
+        name: test
+        state: present

--- a/templates/etc-docker-daemon-json.j2
+++ b/templates/etc-docker-daemon-json.j2
@@ -19,5 +19,9 @@
   "mtu": {{ ansible_default_ipv4.mtu }},
 {% endif %}
 
+{% for key in docker_additional_options %}
+  "{{ key }}": {{ docker_additional_options[key] | to_json }},
+{% endfor %}
+
   "debug": {{ docker_debug | bool | to_json  }}
 }

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -14,6 +14,18 @@ def test_docker_info(Command, Sudo):
         Command.check_output('docker info')
 
 
+def test_docker_socket_unprivileged(Command, Sudo):
+    with Sudo('test'):
+        r = Command('docker info')
+    assert r.rc > 0
+    assert 'permission denied' in r.stderr
+
+
+def test_docker_tcp_unprivileged(Command, Sudo):
+    with Sudo('test'):
+        Command.check_output('DOCKER_HOST=tcp://127.0.0.1:4243 docker info')
+
+
 def test_docker_run(Command, Sudo):
     with Sudo():
         out = Command.check_output('docker run busybox id')


### PR DESCRIPTION
Allows additional options (such as `hosts`) to be set in `/etc/docker/daemon.json`

Additional functionality, tag `2.1.0`?

@aleksandra-tarkowska