### PR TITLE
Option to install distro package instead of upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Role Variables
 --------------
 
 Optional variables:
+- `docker_install_upstream`: If `True` install the upstream docker package, otherwise install the distribution version, default `True`
 - `docker_groupmembers`: A list of users who will be added to the `docker` system group, allows docker to be run without sudo
 - `docker_use_ipv4_nic_mtu`: Force Docker to use the MTU set by the main IPV4 interface. This may be necessary on virtualised hosts, see comment in `defaults/main.yml`.
 - `docker_additional_options`: Dictionary of additional Docker configuration options.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults file for roles/docker
 
+# Use the upstream docker community edition, if False use the distribution version
+docker_install_upstream: True
+
 # Set to True if using a custom storage configuration
 docker_use_custom_storage: False
 

--- a/molecule.yml
+++ b/molecule.yml
@@ -18,11 +18,18 @@ vagrant:
         cpus: 1
   instances:
     - name: docker
+    - name: docker-distro
     - name: docker-inactive
 
 docker:
   containers:
   - name: docker
+    image: openmicroscopy/centos-systemd-ip
+    image_version: latest
+    privileged: True
+    ansible_groups:
+    - docker-hosts
+  - name: docker-distro
     image: openmicroscopy/centos-systemd-ip
     image_version: latest
     privileged: True
@@ -45,6 +52,8 @@ ansible:
       docker_use_ipv4_nic_mtu: True
     docker-inactive:
       docker_systemd_setup: False
+    docker-distro:
+      docker_install_upstream: False
 
 verifier:
   name: testinfra

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: docker | install docker
   become: yes
   yum:
-    pkg: docker-ce
+    pkg: "{{ docker_install_upstream | ternary ('docker-ce', 'docker') }}"
     state: present
 
 - name: docker | setup lvm docker-pool

--- a/templates/docker-repo.j2
+++ b/templates/docker-repo.j2
@@ -1,6 +1,6 @@
 [dockerrepo]
 name=Docker Repository
 baseurl=https://yum.dockerproject.org/repo/{{ docker_repo_version }}/centos/7
-enabled=1
+enabled={{ docker_install_upstream | ternary (1, 0) }}
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg

--- a/tests/test_docker-distro.py
+++ b/tests/test_docker-distro.py
@@ -1,7 +1,7 @@
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    '.molecule/ansible_inventory').get_hosts('docker')
+    '.molecule/ansible_inventory').get_hosts('docker-distro')
 
 
 def test_service_running_and_enabled(Service):
@@ -18,7 +18,7 @@ def test_docker_socket_unprivileged(Command, Sudo):
     with Sudo('test'):
         r = Command('docker info')
     assert r.rc > 0
-    assert 'permission denied' in r.stderr
+    assert 'Cannot connect' in r.stderr
 
 
 def test_docker_tcp_unprivileged(Command, Sudo):
@@ -33,5 +33,5 @@ def test_docker_run(Command, Sudo):
 
 
 def test_docker_package(Package):
-    assert Package('docker-ce').is_installed
-    assert not Package('docker').is_installed
+    assert Package('docker').is_installed
+    assert not Package('docker-ce').is_installed


### PR DESCRIPTION
The Kubernetes installer requires additional configuration if the non-distribution Docker is installed. It's easier to just install the distro version.

Tag: new feature, `2.2.0`