### PR TITLE
Allow docker_version to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Role Variables
 
 Optional variables:
 - `docker_install_upstream`: If `True` install the upstream docker package, otherwise install the distribution version, default `True`
+- `docker_version`: Install a particular version of docker, e.g. `17.12.1.ce-1.el7.centos`, default current
 - `docker_groupmembers`: A list of users who will be added to the `docker` system group, allows docker to be run without sudo
 - `docker_use_ipv4_nic_mtu`: Force Docker to use the MTU set by the main IPV4 interface. This may be necessary on virtualised hosts, see comment in `defaults/main.yml`.
 - `docker_additional_options`: Dictionary of additional Docker configuration options.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@
 # Use the upstream docker community edition, if False use the distribution version
 docker_install_upstream: True
 
+# Docker version to be installed
+docker_version: ''
+
 # Set to True if using a custom storage configuration
 docker_use_custom_storage: False
 

--- a/molecule.yml
+++ b/molecule.yml
@@ -50,6 +50,9 @@ ansible:
   host_vars:
     docker:
       docker_use_ipv4_nic_mtu: True
+      # Latest version 17.12.1.ce-1.el7.centos has a bug that prevents
+      # testing on travis: https://github.com/docker/for-linux/issues/219
+      docker_version: 17.09.1.ce-1.el7.centos
     docker-inactive:
       docker_systemd_setup: False
     docker-distro:

--- a/molecule.yml
+++ b/molecule.yml
@@ -54,6 +54,7 @@ ansible:
       docker_systemd_setup: False
     docker-distro:
       docker_install_upstream: False
+      docker_version: 1.12.6
 
 verifier:
   name: testinfra

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: docker | install docker
   become: yes
   yum:
-    pkg: "{{ docker_install_upstream | ternary ('docker-ce', 'docker') }}"
+    pkg: "{{ docker_install_upstream | ternary ('docker-ce', 'docker') }}{{ (docker_version | length > 0) | ternary('-' + docker_version, '') }}"
     state: present
 
 - name: docker | setup lvm docker-pool

--- a/tests/test_docker-distro.py
+++ b/tests/test_docker-distro.py
@@ -35,3 +35,8 @@ def test_docker_run(Command, Sudo):
 def test_docker_package(Package):
     assert Package('docker').is_installed
     assert not Package('docker-ce').is_installed
+
+
+def test_docker_version(Command):
+    assert Command.check_output(
+        "docker version --format '{{.Server.Version}}'") == '1.12.6'


### PR DESCRIPTION
The latest version of Docker has a bug which prevents docker being tested in docker on Travis, e.g. https://github.com/manics/ansible-role-anonymous-ftp/commit/7c7f7731e4dcb7a430a79fc09a3dea69042149ab

This adds the ability to specify the Docker version.

Tag: `2.3.0`