### PR TITLE
Allow yum repo releasever to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Optional variables:
 - `docker_use_custom_network`: If `True` use a custom network configuration, default `False`
 - `docker_systemd_setup`: Set this to False to disable automatic systemd configuration, default `False`.
   You may wish to use this when building virtualisation images.
+- `docker_repo_force_releasever`: The repo config uses the `$releasever` variables. On some systems this may not work, if necessary you can forcibly override it by setting this variable.
 
 
 ### Custom storage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ docker_groupmembers: []
 docker_systemd_setup: true
 
 # Override the releasever in the yum repo configuration
-docker_repo_force_releasever: ''
+docker_repo_force_releasever: '$releasever'
 
 
 ######################################################################

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,9 @@ docker_groupmembers: []
 # Setup systemd services
 docker_systemd_setup: true
 
+# Override the releasever in the yum repo configuration
+docker_repo_force_releasever: ''
+
 
 ######################################################################
 # Expert users only!

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,10 +23,7 @@
   copy:
     content: >-
       {{ _docker_repo.content | b64decode |
-         regex_replace('\$releasever',
-           (docker_repo_force_releasever | length > 0) | ternary(
-           docker_repo_force_releasever, '$releasever')
-         )
+         regex_replace('\$releasever', docker_repo_force_releasever)
       }}
     dest: /etc/yum.repos.d/docker-ce.repo
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,16 +4,36 @@
 - include: redhat.yml
   when: ansible_distribution == 'RedHat'
 
-- name: docker | setup repository
+- name: docker | download repository config
   become: true
   get_url:
-    dest: /etc/yum.repos.d/docker-ce.repo
+    dest: /etc/yum.repos.d/docker-ce.repo.original
     url: https://download.docker.com/linux/centos/docker-ce.repo
+
+- name: docker | read repository config
+  become: true
+  slurp:
+    src: /etc/yum.repos.d/docker-ce.repo.original
+  register: _docker_repo
+  # Unnecessarily long output
+  no_log: true
+
+- name: docker | write repository config
+  become: true
+  copy:
+    content: >-
+      {{ _docker_repo.content | b64decode |
+         regex_replace('\$releasever',
+           (docker_repo_force_releasever | length > 0) | ternary(
+           docker_repo_force_releasever, '$releasever')
+         )
+      }}
+    dest: /etc/yum.repos.d/docker-ce.repo
 
 - name: docker | install docker
   become: true
   yum:
-    pkg: >
+    name: >
       docker-ce{{ (docker_version | length > 0) |
       ternary('-' + docker_version, '') }}
     state: present


### PR DESCRIPTION
The upstream Docker CE repo supports `releasever=7`, but some managed servers use a variant such as `7server` that is not supported. A new variable `docker_repo_force_releasever` allows `releasever` to be forcibly set in the docker yum repo config.

Tag: new feature `3.1.0`