### PR TITLE
fix indent

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,12 +13,12 @@ galaxy_info:
   namespace: ome
   galaxy_tags: []
 
-  dependencies:
-    - role: ome.lvm_partition
-      lvm_vgname: "{{ docker_vgname }}"
-      lvm_lvname: docker-volume
-      lvm_lvmount: /var/lib/docker
-      lvm_lvsize: "{{ docker_volumesize }}"
-      lvm_lvfilesystem: "{{ docker_lvfilesystem }}"
-      lvm_lvopts: "{{ docker_lvopts | default(None) }}"
-      when: docker_use_custom_storage
+dependencies:
+  - role: ome.lvm_partition
+    lvm_vgname: "{{ docker_vgname }}"
+    lvm_lvname: docker-volume
+    lvm_lvmount: /var/lib/docker
+    lvm_lvsize: "{{ docker_volumesize }}"
+    lvm_lvfilesystem: "{{ docker_lvfilesystem }}"
+    lvm_lvopts: "{{ docker_lvopts | default(None) }}"
+    when: docker_use_custom_storage


### PR DESCRIPTION
The way it was formatting implies that ``dependies`` is a field of ``galaxy_info``
cc @khaledk2 @pwalczysko 