### PR TITLE
fix min version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install upstream Docker
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.3
+  min_ansible_version: 2.10
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
fix min version to 10 since we use dependencies

This was missed when the support for Rocky 9