### PR TITLE
Become root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
 - ansible.builtin.import_tasks: pre_tasks.yml
 
 - name: docker | Import a key for docker
+  become: true
   ansible.builtin.rpm_key:
     state: present
     key: https://download.docker.com/linux/centos/gpg
@@ -58,6 +59,7 @@
 
 # change service file to remove _H options from service file to be able to use daemon.json
 - name: docker | remove options from service
+  become: true
   ansible.builtin.replace:
     path:  /usr/lib/systemd/system/docker.service
     regexp: ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock


### PR DESCRIPTION
Fixes the issues on rocky9:
```
TASK [ome.docker : docker | Import a key for docker] *******************************************************************************************************************************
fatal: [2f5d1f82-2aad-433b-ab9f-98c5fe25ffa5]: FAILED! => {"changed": false, "msg": "error: can't create transaction lock on /var/lib/rpm/.rpm.lock (Permission denied)\nerror: /tmp/tmp2z1kra4m: key 1 import failed.\n"}

TASK [ome.docker : docker | remove options from service] ***************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: PermissionError: [Errno 13] Permission denied: b'/home/rocky/.ansible/tmp/ansible-tmp-1709736518.0505211-36018-114917932697348/tmptvikibho' -> b'/usr/lib/systemd/system/docker.service'
fatal: [2f5d1f82-2aad-433b-ab9f-98c5fe25ffa5]: FAILED! => {"changed": false, "msg": "The destination directory (/usr/lib/systemd/system) is not writable by the current user. Error was: [Errno 13] Permission denied: b'/usr/lib/systemd/system/.ansible_tmp56hsu55gdocker.service'"}
```
